### PR TITLE
Improve subscribers instrumentation

### DIFF
--- a/lib/plug/subscriber.ex
+++ b/lib/plug/subscriber.ex
@@ -20,7 +20,38 @@ defmodule ConduitAppsignal.Plug.Subscriber do
 
   def call(message, next, opts) do
     action = "#{inspect(opts[:subscriber])}.process"
-    Appsignal.Transaction.set_action(action)
+
+    tags = %{
+      source: message.source,
+      destination: message.destination,
+      user_id: message.user_id,
+      correlation_id: message.correlation_id,
+      message_id: message.message_id
+    }
+
+    environment =
+      Map.merge(
+        %{
+          content_type: message.content_type,
+          content_encoding: message.content_encoding,
+          created_by: message.created_by,
+          created_at: message.created_at
+        },
+        message.headers
+      )
+
+    custom = %{
+      assigns: message.assigns,
+      private: message.private
+    }
+    
+    action
+    |> Appsignal.Transaction.set_action()
+    |> Appsignal.Transaction.set_sample_data("environment", environment)
+    |> Appsignal.Transaction.set_sample_data("tags", tags)
+    |> Appsignal.Transaction.set_sample_data("params", message.body)
+    |> Appsignal.Transaction.set_sample_data("custom_data", custom)
+
     instrument("message.process", action, fn ->
       next.(message)
     end)

--- a/lib/plug/subscriber.ex
+++ b/lib/plug/subscriber.ex
@@ -29,28 +29,17 @@ defmodule ConduitAppsignal.Plug.Subscriber do
       message_id: message.message_id
     }
 
-    environment =
-      Map.merge(
-        %{
-          content_type: message.content_type,
-          content_encoding: message.content_encoding,
-          created_by: message.created_by,
-          created_at: message.created_at
-        },
-        message.headers
-      )
-
-    custom = %{
-      assigns: message.assigns,
-      private: message.private
+    environment = %{
+      content_type: message.content_type,
+      content_encoding: message.content_encoding,
+      created_by: message.created_by,
+      created_at: message.created_at
     }
     
     action
     |> Appsignal.Transaction.set_action()
     |> Appsignal.Transaction.set_sample_data("environment", environment)
     |> Appsignal.Transaction.set_sample_data("tags", tags)
-    |> Appsignal.Transaction.set_sample_data("params", message.body)
-    |> Appsignal.Transaction.set_sample_data("custom_data", custom)
 
     instrument("message.process", action, fn ->
       next.(message)


### PR DESCRIPTION
Hi, we are using this library at my current job and it's very nice and helpful, thanks for the work :)

Afterwhile was necessary to send more data from the message that is processed to appsignal, like correlation id's, message body, etc. I had added some functionality based on `Coduit.Message` struct and would be nice if we had this on the lib.